### PR TITLE
Add a function to return all the keys of the entries that hold the same value.

### DIFF
--- a/map.c
+++ b/map.c
@@ -354,6 +354,39 @@ void hashmap_iterate(hashmap* m, hashmap_callback c, void* user_ptr)
 	}
 }
 
+void ** hashmap_get_same_values(hashmap * m, uintptr_t value){
+
+	struct bucket* current = m->first;
+	
+	int co = 0;
+
+	int sk = 1; // size of keys array 
+	void ** keys = malloc(sizeof(void*)* sk);
+
+	while (current != NULL)
+	{
+		#ifdef __HASHMAP_REMOVABLE
+		// "tombstone" check
+		if (current->key != NULL)
+		#endif
+			
+		//we check and store the key
+		if(current->value == value){
+			keys[sk-1] = current->key;
+			sk++;
+			keys = realloc(keys, sizeof(void*) * sk);
+		}
+		current = current->next;
+
+		if (co > 1000)
+		{
+			break;
+		}
+		co++;
+
+	}
+	return keys;
+}
 /*void bucket_dump(hashmap* m)
 {
 	for (int i = 0; i < m->capacity; i++)

--- a/map.h
+++ b/map.h
@@ -67,6 +67,10 @@ int hashmap_size(hashmap* map);
 // the element's key, key size, value, and `usr` will be passed to `c`.
 void hashmap_iterate(hashmap* map, hashmap_callback c, void* usr);
 
+// get all enteries that have the same values returned as an array of keys
+// it actually iterates the whole map as hashmap_iterate does.
+void ** hashmap_get_same_values(hashmap * m, uintptr_t value);
+
 // dumps bucket info for debugging.
 // allows you to see how many collisions you are getting.
 // `0` is an empty bucket, `1` is occupied, and `x` is removed.


### PR DESCRIPTION
Hi!
I just added a new function to the API which searches for a given value in the whole map and returns all the keys that holds that value. 
`// get all enteries that have the same values returned as an array of keys
// it actually iterates the whole map as hashmap_iterate does.
void ** hashmap_get_same_values(hashmap * m, uintptr_t value);`