### PR TITLE
Make key argument const in hashmap_get(), hashmap_remove() and hashmap_remove_free()

### DIFF
--- a/map.c
+++ b/map.c
@@ -167,7 +167,7 @@ static inline uint32_t hash_data(const unsigned char* data, size_t size)
 	return hash ^ hash >> 32;
 }
 
-static struct bucket* find_entry(hashmap* m, void* key, size_t ksize, uint32_t hash)
+static struct bucket* find_entry(hashmap* m, const void* key, size_t ksize, uint32_t hash)
 {
 	uint32_t index = hash % m->capacity;
 
@@ -292,7 +292,7 @@ void hashmap_set_free(hashmap* m, void* key, size_t ksize, uintptr_t val, hashma
 	entry->value = val;
 }
 
-bool hashmap_get(hashmap* m, void* key, size_t ksize, uintptr_t* out_val)
+bool hashmap_get(hashmap* m, const void* key, size_t ksize, uintptr_t* out_val)
 {
 	uint32_t hash = hash_data(key, ksize);
 	struct bucket* entry = find_entry(m, key, ksize, hash);
@@ -306,7 +306,7 @@ bool hashmap_get(hashmap* m, void* key, size_t ksize, uintptr_t* out_val)
 #ifdef __HASHMAP_REMOVABLE
 // doesn't "remove" the element per se, but it will be ignored.
 // the element will eventually be removed when the map is resized.
-void hashmap_remove(hashmap* m, void* key, size_t ksize)
+void hashmap_remove(hashmap* m, const void* key, size_t ksize)
 {
 	uint32_t hash = hash_data(key, ksize);
 	struct bucket* entry = find_entry(m, key, ksize, hash);
@@ -323,7 +323,7 @@ void hashmap_remove(hashmap* m, void* key, size_t ksize)
 	}
 }
 
-void hashmap_remove_free(hashmap* m, void* key, size_t ksize, hashmap_callback c, void* usr)
+void hashmap_remove_free(hashmap* m, const void* key, size_t ksize, hashmap_callback c, void* usr)
 {
 	uint32_t hash = hash_data(key, ksize);
 	struct bucket* entry = find_entry(m, key, ksize, hash);

--- a/map.h
+++ b/map.h
@@ -51,13 +51,13 @@ bool hashmap_get_set(hashmap* map, void* key, size_t ksize, uintptr_t* out_in);
 // which means you can free the old key in the callback if applicable.
 void hashmap_set_free(hashmap* map, void* key, size_t ksize, uintptr_t value, hashmap_callback c, void* usr);
 
-bool hashmap_get(hashmap* map, void* key, size_t ksize, uintptr_t* out_val);
+bool hashmap_get(hashmap* map, const void* key, size_t ksize, uintptr_t* out_val);
 
 #ifdef __HASHMAP_REMOVABLE
-void hashmap_remove(hashmap *map, void *key, size_t ksize);
+void hashmap_remove(hashmap *map, const void *key, size_t ksize);
 
 // same as `hashmap_remove()`, but it allows you to free an entry's data first via a callback.
-void hashmap_remove_free(hashmap* m, void* key, size_t ksize, hashmap_callback c, void* usr);
+void hashmap_remove_free(hashmap* m, const void* key, size_t ksize, hashmap_callback c, void* usr);
 #endif
 
 int hashmap_size(hashmap* map);


### PR DESCRIPTION
The hashmap keys are currently `void*`, which means passing a type like `const char*` to a hashmap function requires an explicit cast to remove the const-ness:

```c
const char* key = "hello";
hashmap_get(m, (char*)key, 5, &i);
```

Not using the cast may generate a warning in C, or an error in C++. (In C++ it even applies to string literals).

This PR makes the cast unnecessary for `hashmap_get()`, `hashmap_remove()` and `hashmap_remove_free()`, by making the key argument itself `const void*`. This shouldn't affect passing non-const keys to these functions - all it does is declare that the functions treat the keys as read-only.

Originally, I wanted to make keys `const` everywhere in the library, but then I realized that would go against the usecase of freeing a key from within a hashmap_callback. It would still be possible - it'd just need a `(void*)` cast inside the callback (while getting rid of the casts for `hashmap_set()`). The user already has a responsibility to know what can be done with their keys, so technically this wouldn't change much, and it could be explained in the readme. But for this PR, I decided to start small and only change the functions that never give their keys back to the user. Lemme know if a more complete change to const keys sounds like a good idea :)
