### PR TITLE
Adjust get/set functions to return int.

### DIFF
--- a/map.h
+++ b/map.h
@@ -15,7 +15,6 @@
 //#define __HASHMAP_REMOVABLE
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <stddef.h>
 
 // hashmaps can associate keys with pointer values or integral types.
@@ -24,7 +23,7 @@ typedef struct hashmap hashmap;
 // a callback type used for iterating over a map/freeing entries:
 // `void <function name>(void* key, size_t size, uintptr_t value, void* usr)`
 // `usr` is a user pointer which can be passed through `hashmap_iterate`.
-typedef void (*hashmap_callback)(void *key, size_t ksize, uintptr_t value, void *usr);
+typedef int (*hashmap_callback)(void *key, size_t ksize, uintptr_t value, void *usr);
 
 hashmap* hashmap_create(void);
 
@@ -36,22 +35,24 @@ void hashmap_free(hashmap* map);
 // does not make a copy of `key`.
 // you must copy it yourself if you want to guarantee its lifetime,
 // or if you intend to call `hashmap_key_free`.
-void hashmap_set(hashmap* map, const void* key, size_t ksize, uintptr_t value);
+// returns -1 on error.
+int hashmap_set(hashmap* map, const void* key, size_t ksize, uintptr_t value);
 
 // adds an entry if it doesn't exist, using the value of `*out_in`.
 // if it does exist, it sets value in `*out_in`, meaning the value
 // of the entry will be in `*out_in` regardless of whether or not
 // it existed in the first place.
-// returns true if the entry already existed, returns false otherwise.
-bool hashmap_get_set(hashmap* map, const void* key, size_t ksize, uintptr_t* out_in);
+// returns -1 on error.
+// returns 1 if the entry already existed, returns 0 otherwise.
+int hashmap_get_set(hashmap* map, const void* key, size_t ksize, uintptr_t* out_in);
 
 // similar to `hashmap_set()`, but when overwriting an entry,
 // you'll be able properly free the old entry's data via a callback.
 // unlike `hashmap_set()`, this function will overwrite the original key pointer,
 // which means you can free the old key in the callback if applicable.
-void hashmap_set_free(hashmap* map, const void* key, size_t ksize, uintptr_t value, hashmap_callback c, void* usr);
+int hashmap_set_free(hashmap* map, const void* key, size_t ksize, uintptr_t value, hashmap_callback c, void* usr);
 
-bool hashmap_get(hashmap* map, const void* key, size_t ksize, uintptr_t* out_val);
+int hashmap_get(hashmap* map, const void* key, size_t ksize, uintptr_t* out_val);
 
 #ifdef __HASHMAP_REMOVABLE
 void hashmap_remove(hashmap *map, const void *key, size_t ksize);
@@ -65,7 +66,9 @@ int hashmap_size(hashmap* map);
 // iterate over the map, calling `c` on every element.
 // goes through elements in the order they were added.
 // the element's key, key size, value, and `usr` will be passed to `c`.
-void hashmap_iterate(hashmap* map, hashmap_callback c, void* usr);
+// if `c` returns -1 the iteration is aborted.
+// returns the last result of `c`
+int hashmap_iterate(hashmap* map, hashmap_callback c, void* usr);
 
 // dumps bucket info for debugging.
 // allows you to see how many collisions you are getting.


### PR DESCRIPTION
Functions that returned true now return 1, false now returns 0. Functions with no return now return 0.

This allows all these functions to return -1 on error as internally calloc could fail in low memory conditions.

stdbool.h is no longer needed.

The hashmap_callback can now return -1 to signal hashmap_iterate to abort. hashmap_iterate now returns the result of the last hashmap_callback.

hashmap_set_free now returns the result of hashmap_callback.

Fixes #10.